### PR TITLE
Make work in the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
   "name": "google-spreadsheet-stream",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Streaming interface for google spreadsheets",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/christensenep/google-spreadsheet-stream"
+  },
   "main": "index.js",
   "dependencies": {
-    "request" : "~2.27.0",
+    "request" : "~2.79.0",
     "JSONStream" : "~0.7.1",
     "through" : "~2.3.4"
   },


### PR DESCRIPTION
Upgrade `request` to a browser compatible version. Bump patch version while we're at it and add the github repo to package.json to link from npm.